### PR TITLE
Fix typo of dom event.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -119,7 +119,7 @@ declare module 'gg-editor' {
     domX?: number
     domY?: number
     /** DOM 原生事件 */
-    domeEvent?: any
+    domEvent?: any
     /** drag 拖动图项 */
     currentIem?: any
     /** drag 拖动图形 */


### PR DESCRIPTION
Currently DOM event key is "domEvent" but named as "domeEvent" in interface. This commit will fix this typo.

![image](https://user-images.githubusercontent.com/8896124/64023763-9dbf2600-cb6b-11e9-90bd-5403f6396ef1.png)
